### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/bump-version-and-build.yml
+++ b/.github/workflows/bump-version-and-build.yml
@@ -62,7 +62,7 @@ jobs:
         echo "::set-env name=SOFTWARE_VERSION::$software_version"
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: dailyk/test-gh-action-versioning
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore